### PR TITLE
[Admin] Update carouselMoveButton

### DIFF
--- a/apps/admin/src/components/Carousel/Controller/index.tsx
+++ b/apps/admin/src/components/Carousel/Controller/index.tsx
@@ -36,9 +36,9 @@ const CarouselController: React.FC<CarouselControllerProps> = ({
 
   return (
     <S.CarouselBar>
-      <S.CursorWrapper onClick={moveLeft}>
+      <S.MoveButton onClick={moveLeft}>
         <ChevronIcon turn={'left'} />
-      </S.CursorWrapper>
+      </S.MoveButton>
       <S.DotWrapper>
         {data?.fileInfo.map((file, i) => (
           <S.Dot
@@ -53,9 +53,9 @@ const CarouselController: React.FC<CarouselControllerProps> = ({
           />
         ))}
       </S.DotWrapper>
-      <S.CursorWrapper onClick={moveRight}>
+      <S.MoveButton onClick={moveRight}>
         <ChevronIcon turn={'right'} />
-      </S.CursorWrapper>
+      </S.MoveButton>
     </S.CarouselBar>
   );
 };

--- a/apps/admin/src/components/Carousel/Controller/style.ts
+++ b/apps/admin/src/components/Carousel/Controller/style.ts
@@ -24,6 +24,6 @@ export const Dot = styled.div`
   transition: all 0.3s;
 `;
 
-export const CursorWrapper = styled.div`
+export const MoveButton = styled.button`
   cursor: pointer;
 `;


### PR DESCRIPTION
## 개요 💡

> carousel의 아래 사진에 해당되는 부분을 div 태그에서 button 태그로 수정하였습니다.
<img width="626" alt="image" src="https://github.com/themoment-team/official-gsm-front/assets/106712562/a0fb64d0-d855-43e9-88f3-52d1ca7bf5f1">


## 작업내용 ⌨️
+ tag : div -> button
+ name : CursorWrapper -> MoveButton

제작시에는 cursor-pointer의 역할만 한다고 생각하여 CursorWrapper라는 이름과 div 태그를 채택하였지만 button임을 알려주셔서 수정하였습니다. 감사합니다

+ 다른 컴포넌트들도 이와 같이 태그 변경이 필요한 부분이 있는지 찾아보았으나 발견하지 못하였습니다. 있다면 말씀 부탁드립니다!
