### PR TITLE
[UI] Update writerAndDate

### DIFF
--- a/apps/admin/src/components/CommonDetail/index.tsx
+++ b/apps/admin/src/components/CommonDetail/index.tsx
@@ -19,6 +19,7 @@ const CommonDetail: React.FC<CommonDetailProps> = ({ postSeq }) => {
         <S.CommonDetailWrapper>
           <S.Title>{data.postTitle}</S.Title>
           <WriterAndDate
+            workspace='admin'
             margin='0.75rem 0'
             createdAt={data.createdAt}
             postWriter={data.postWriter}

--- a/apps/admin/src/components/GalleryCard/index.tsx
+++ b/apps/admin/src/components/GalleryCard/index.tsx
@@ -30,6 +30,7 @@ const GalleryCard: React.FC<GalleryCardProps> = ({
     <S.ContentPreview className='text'>{contentPreview}</S.ContentPreview>
     <S.WiterAndDateWrapper>
       <WriterAndDate
+        workspace='admin'
         createdAt={createdAt}
         postWriter={postWriter}
         margin='1.5rem 0 0 0'

--- a/apps/admin/src/components/PostCard/index.tsx
+++ b/apps/admin/src/components/PostCard/index.tsx
@@ -16,7 +16,11 @@ const PostCard: React.FC<PostCardProps> = ({
       <S.Title>{postTitle}</S.Title>
       <S.ContentPreview>{contentPreview}</S.ContentPreview>
     </S.TitleWrap>
-    <WriterAndDate postWriter={postWriter} createdAt={createdAt} />
+    <WriterAndDate
+      workspace='admin'
+      postWriter={postWriter}
+      createdAt={createdAt}
+    />
   </S.PostCard>
 );
 

--- a/apps/client/src/components/GalleryCard/index.tsx
+++ b/apps/client/src/components/GalleryCard/index.tsx
@@ -21,7 +21,7 @@ const GalleryCard: React.FC<GalleryCardProps> = ({
       <S.Title className='text'>{postTitle}</S.Title>
       <S.ContentPreview className='text'>{contentPreview}</S.ContentPreview>
     </S.TextBox>
-    <DateComponent createdAt={createdAt} />
+    <DateComponent createdAt={createdAt} workspace='client' />
   </S.GalleryCard>
 );
 

--- a/apps/client/src/components/ListPage/PostCard/index.tsx
+++ b/apps/client/src/components/ListPage/PostCard/index.tsx
@@ -18,7 +18,11 @@ const ListPagePostCard: React.FC<ListPagePostCardProps> = ({
       <S.PostIndex>#{postIndex}</S.PostIndex>
       <S.PostTitle>{postTitle}</S.PostTitle>
     </S.IndexAndTitle>
-    <WriterAndDate postWriter={postWriter} createdAt={createdAt} />
+    <WriterAndDate
+      workspace='client'
+      postWriter={postWriter}
+      createdAt={createdAt}
+    />
   </S.PostCard>
 );
 

--- a/apps/client/src/components/PostDetailHead/index.tsx
+++ b/apps/client/src/components/PostDetailHead/index.tsx
@@ -23,6 +23,7 @@ const PostDetailProps: React.FC<PostDetailHeadProps> = ({ postSeq }) => {
           <S.CategoryText>{categories[data.category]}</S.CategoryText>
           <S.Title>{data.postTitle}</S.Title>
           <WriterAndDate
+            workspace='client'
             postWriter={data.postWriter}
             createdAt={data.createdAt}
           />

--- a/packages/ui/src/components/DateComponent/index.tsx
+++ b/packages/ui/src/components/DateComponent/index.tsx
@@ -3,16 +3,22 @@ import { formatDate } from 'common';
 
 interface DateProps {
   createdAt: string;
+  workspace: 'client' | 'admin';
 }
 
-const DateComponent: React.FC<DateProps> = ({ createdAt }) => {
+const DateComponent: React.FC<DateProps> = ({ createdAt, workspace }) => {
   const createdAtDate = new Date(createdAt);
 
   const year = createdAtDate.getFullYear();
   const month = formatDate(createdAtDate.getMonth() + 1);
   const date = formatDate(createdAtDate.getDate());
 
-  return <S.Date dateTime={createdAt}>{`${year}.${month}.${date}`}</S.Date>;
+  return (
+    <S.Date
+      workspace={workspace}
+      dateTime={createdAt}
+    >{`${year}.${month}.${date}`}</S.Date>
+  );
 };
 
 export default DateComponent;

--- a/packages/ui/src/components/DateComponent/style.ts
+++ b/packages/ui/src/components/DateComponent/style.ts
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
-export const Date = styled.time`
+export const Date = styled.time<{ workspace: 'client' | 'admin' }>`
+  ${({ theme, workspace }) =>
+    workspace === 'client' ? theme.typo.body1 : theme.typo.body2}
+  color: ${({ theme }) => theme.color.gray['070']};
   font-weight: 400;
-  color: #616161;
-  font-size: 1.125rem;
-  line-height: 1.6875rem;
   font-feature-settings: 'tnum';
 `;

--- a/packages/ui/src/components/WriterAndDate/index.stories.tsx
+++ b/packages/ui/src/components/WriterAndDate/index.stories.tsx
@@ -12,9 +12,18 @@ export default {
 
 type Story = StoryObj<typeof WriterAndDate>;
 
-export const Primary: Story = {
+export const Client: Story = {
   args: {
     postWriter: '최장우',
     createdAt: '2023-05-03T19:47:01.250197',
+    workspace: 'client',
+  },
+};
+
+export const Admin: Story = {
+  args: {
+    postWriter: '최장우',
+    createdAt: '2023-05-03T19:47:01.250197',
+    workspace: 'admin',
   },
 };

--- a/packages/ui/src/components/WriterAndDate/index.tsx
+++ b/packages/ui/src/components/WriterAndDate/index.tsx
@@ -8,21 +8,26 @@ interface WriterAndDateProps {
   postWriter: string;
   createdAt: string;
   margin?: string;
+  workspace: 'client' | 'admin';
 }
 
 const WriterAndDate: React.FC<WriterAndDateProps> = ({
   postWriter,
   createdAt,
   margin,
+  workspace,
 }) => (
   <S.WriterAndDateWrapper
-    css={css`
-      margin: ${margin};
-    `}
+    css={
+      margin &&
+      css`
+        margin: ${margin};
+      `
+    }
   >
-    <S.WriterText>{postWriter}</S.WriterText>
+    <S.WriterText workspace={workspace}>{postWriter}</S.WriterText>
     <S.Dot />
-    <DateComponent createdAt={createdAt} />
+    <DateComponent createdAt={createdAt} workspace={workspace} />
   </S.WriterAndDateWrapper>
 );
 

--- a/packages/ui/src/components/WriterAndDate/style.ts
+++ b/packages/ui/src/components/WriterAndDate/style.ts
@@ -6,16 +6,16 @@ export const WriterAndDateWrapper = styled.div`
   gap: 0.5rem;
 `;
 
-export const WriterText = styled.p`
-  font-weight: 400;
-  font-size: 1.125rem;
+export const WriterText = styled.p<{ workspace: 'client' | 'admin' }>`
+  ${({ theme, workspace }) =>
+    workspace === 'client' ? theme.typo.body1 : theme.typo.body2}
   line-height: 1.6875rem;
-  color: #616161;
+  color: ${({ theme }) => theme.color.gray['070']};
 `;
 
 export const Dot = styled.div`
   width: 0.25rem;
   height: 0.25rem;
   border-radius: 0.125rem;
-  background: #616161;
+  background-color: ${({ theme }) => theme.color.gray['070']};
 `;


### PR DESCRIPTION
## 개요 💡

> admin과 client에 따라 writerAndDate의 `font-size`를 조정하였습니다.

## 작업내용 ⌨️

+ client
<img width="175" alt="image" src="https://github.com/themoment-team/official-gsm-front/assets/106712562/26e4c3c3-ce9a-463e-b05b-e095daac9c09">

+ admin
<img width="160" alt="image" src="https://github.com/themoment-team/official-gsm-front/assets/106712562/44354e7c-fbb3-4cab-bfd3-e6dde1e1a7c2">


writerAndDate 컴포넌트의 prop을 추가하였습니다.
+ workspace: 'client' | 'admin'


