### PR TITLE
[Client] LinkToHelloGSM Responsive

### DIFF
--- a/apps/client/src/components/LinkToHelloGSM/style.ts
+++ b/apps/client/src/components/LinkToHelloGSM/style.ts
@@ -27,6 +27,14 @@ export const LinkToHelloGSMWrapper = styled.a`
       background-position: 0% 50%;
     }
   }
+
+  @media ${({ theme }) => theme.breakPoint['1440']} {
+    width: calc(100vw - 12.5rem);
+  }
+
+  @media ${({ theme }) => theme.breakPoint['1024']} {
+    width: calc(100vw - 7.5rem);
+  }
 `;
 
 export const TextWrapper = styled.div`
@@ -41,6 +49,10 @@ export const AdmissionText = styled.h3`
   ${({ theme: { typo } }) => typo.h3}
   color: ${({ theme: { color } }) => color.white};
   font-weight: 700;
+
+  @media ${({ theme }) => theme.breakPoint['600']} {
+    ${({ theme: { typo } }) => typo.h5}
+  }
 `;
 
 export const HashTagWrapper = styled.div`
@@ -52,4 +64,8 @@ export const HashTag = styled.h4`
   ${({ theme: { typo } }) => typo.h4}
   color: ${({ theme: { color } }) => color.white};
   font-weight: 400;
+
+  @media ${({ theme }) => theme.breakPoint['600']} {
+    ${({ theme: { typo } }) => typo.body1}
+  }
 `;


### PR DESCRIPTION
## 개요 💡

> LinkToHelloGSM의 반응형을 추가하였습니다.

## 작업내용 ⌨️

아래 사진과 같이 동작합니다.

+ <= 1044 
<img width="729" alt="image" src="https://github.com/themoment-team/official-gsm-front/assets/106712562/a3dfc6ca-0d54-44dc-9603-1c3a2f4278bb">

+ <= 600
<img width="522" alt="image" src="https://github.com/themoment-team/official-gsm-front/assets/106712562/92fb1b5b-88aa-43e0-8e77-38f4ee7383a6">

