### PR TITLE
[Client] section4 responsive

### DIFF
--- a/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
+++ b/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
@@ -29,11 +29,11 @@ interface CardType {
   img: ImageType;
 
   imgResponsive: {
-    width1335: string;
-    height1335: string;
+    width1440: string;
+    height1440: string;
     width600: string;
     height600: string;
-    right1335: string;
+    right1440: string;
     right600: string;
   };
 }
@@ -54,11 +54,11 @@ const CurriculumArray: CardType[] = [
       height: 220,
     },
     imgResponsive: {
-      width1335: '17.875rem',
-      height1335: '15.125rem',
+      width1440: '17.875rem',
+      height1440: '15.125rem',
       width600: '13.5625rem',
       height600: '12.4375rem',
-      right1335: '3.6875rem',
+      right1440: '3.6875rem',
       right600: '1.25rem',
     },
   },
@@ -77,11 +77,11 @@ const CurriculumArray: CardType[] = [
       height: 260,
     },
     imgResponsive: {
-      width1335: '18.375rem',
-      height1335: '17.75rem',
+      width1440: '18.375rem',
+      height1440: '17.75rem',
       width600: '14rem',
       height600: '13.75rem',
-      right1335: '2.5625rem',
+      right1440: '2.5625rem',
       right600: '1.375rem',
     },
   },
@@ -100,11 +100,11 @@ const CurriculumArray: CardType[] = [
       height: 252,
     },
     imgResponsive: {
-      width1335: '21.875rem',
-      height1335: '16.625rem',
+      width1440: '21.875rem',
+      height1440: '16.625rem',
       width600: '17.1875rem',
       height600: '13.125rem',
-      right1335: '2.4375rem',
+      right1440: '2.4375rem',
       right600: '1.6875rem',
     },
   },
@@ -123,11 +123,11 @@ const CurriculumArray: CardType[] = [
       height: 220,
     },
     imgResponsive: {
-      width1335: '17.25rem',
-      height1335: '15rem',
+      width1440: '17.25rem',
+      height1440: '15rem',
       width600: '15.375rem',
       height600: '13.375rem',
-      right1335: '1.875rem',
+      right1440: '1.875rem',
       right600: '0',
     },
   },
@@ -145,9 +145,9 @@ const CurriculumCards = () => {
       };
     } else if (width <= 1440) {
       return {
-        width: card.imgResponsive.width1335,
-        height: card.imgResponsive.height1335,
-        right: card.imgResponsive.right1335,
+        width: card.imgResponsive.width1440,
+        height: card.imgResponsive.height1440,
+        right: card.imgResponsive.right1440,
       };
     } else {
       return {

--- a/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
+++ b/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
@@ -137,13 +137,13 @@ const CurriculumCards = () => {
   const width = useGetWindowWidth();
 
   const handleResponsiveImg = (card: CardType) => {
-    if (width > 1335) {
+    if (width < 600) {
       return {
-        width: card.img.width,
-        height: card.img.height,
-        right: card.cardPosition.right,
+        width: card.imgResponsive.width600,
+        height: card.imgResponsive.height600,
+        right: card.imgResponsive.right600,
       };
-    } else if (width <= 1335 && width > 600) {
+    } else if (width <= 1335) {
       return {
         width: card.imgResponsive.width1335,
         height: card.imgResponsive.height1335,
@@ -151,9 +151,9 @@ const CurriculumCards = () => {
       };
     } else {
       return {
-        width: card.imgResponsive.width600,
-        height: card.imgResponsive.height600,
-        right: card.imgResponsive.right600,
+        width: card.img.width,
+        height: card.img.height,
+        right: card.cardPosition.right,
       };
     }
   };

--- a/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
+++ b/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
@@ -100,9 +100,9 @@ const CurriculumArray: CardType[] = [
       height: 252,
     },
     imgResponsive: {
-      width1335: 346,
+      width1335: 350,
       height1335: 266,
-      width600: 267,
+      width600: 275,
       height600: 210,
       right1335: '2.4375rem',
       right600: '1.6875rem',

--- a/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
+++ b/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
@@ -143,7 +143,7 @@ const CurriculumCards = () => {
         height: card.imgResponsive.height600,
         right: card.imgResponsive.right600,
       };
-    } else if (width <= 1335) {
+    } else if (width <= 1440) {
       return {
         width: card.imgResponsive.width1335,
         height: card.imgResponsive.height1335,
@@ -166,7 +166,7 @@ const CurriculumCards = () => {
           css={css`
             width: ${card.isSmall ? '30.9375rem' : '44.6875rem'};
 
-            @media (max-width: 1335px) {
+            @media (max-width: 1440px) {
               width: 100%;
             }
             background-color: ${card.bgColor};
@@ -191,7 +191,7 @@ const CurriculumCards = () => {
               bottom: 0;
               right: ${card.cardPosition.right};
 
-              @media (max-width: 1335px) {
+              @media (max-width: 1440px) {
                 right: ${handleResponsiveImg(card).right};
               }
             `}
@@ -201,7 +201,7 @@ const CurriculumCards = () => {
               width={card.img.width}
               height={card.img.height}
               css={css`
-                @media (max-width: 1335px) {
+                @media (max-width: 1440px) {
                   width: ${handleResponsiveImg(card).width};
                   height: ${handleResponsiveImg(card).height};
                 }

--- a/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
+++ b/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
@@ -29,10 +29,10 @@ interface CardType {
   img: ImageType;
 
   imgResponsive: {
-    width1335: number;
-    height1335: number;
-    width600: number;
-    height600: number;
+    width1335: string;
+    height1335: string;
+    width600: string;
+    height600: string;
     right1335: string;
     right600: string;
   };
@@ -54,10 +54,10 @@ const CurriculumArray: CardType[] = [
       height: 220,
     },
     imgResponsive: {
-      width1335: 286,
-      height1335: 242,
-      width600: 217,
-      height600: 199,
+      width1335: '17.875rem',
+      height1335: '15.125rem',
+      width600: '13.5625rem',
+      height600: '12.4375rem',
       right1335: '3.6875rem',
       right600: '1.25rem',
     },
@@ -77,10 +77,10 @@ const CurriculumArray: CardType[] = [
       height: 260,
     },
     imgResponsive: {
-      width1335: 294,
-      height1335: 284,
-      width600: 224,
-      height600: 220,
+      width1335: '18.375rem',
+      height1335: '17.75rem',
+      width600: '14rem',
+      height600: '13.75rem',
       right1335: '2.5625rem',
       right600: '1.375rem',
     },
@@ -100,10 +100,10 @@ const CurriculumArray: CardType[] = [
       height: 252,
     },
     imgResponsive: {
-      width1335: 350,
-      height1335: 266,
-      width600: 275,
-      height600: 210,
+      width1335: '21.875rem',
+      height1335: '16.625rem',
+      width600: '17.1875rem',
+      height600: '13.125rem',
       right1335: '2.4375rem',
       right600: '1.6875rem',
     },
@@ -123,10 +123,10 @@ const CurriculumArray: CardType[] = [
       height: 220,
     },
     imgResponsive: {
-      width1335: 276,
-      height1335: 240,
-      width600: 246,
-      height600: 214,
+      width1335: '17.25rem',
+      height1335: '15rem',
+      width600: '15.375rem',
+      height600: '13.375rem',
       right1335: '1.875rem',
       right600: '0',
     },

--- a/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
+++ b/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
@@ -4,16 +4,18 @@ import Image from 'next/image';
 
 import { css } from '@emotion/react';
 
+import { useGetWindowWidth } from 'client/hooks';
+
 import { theme } from 'common';
 
 import * as S from './style';
 
 interface ImageType extends ImgHTMLAttributes<HTMLImageElement> {
-  width?: number;
-  height?: number;
+  width: number;
+  height: number;
 }
 
-export interface CardType {
+interface CardType {
   isSmall: boolean;
   bgColor: string;
   color: string;
@@ -25,6 +27,15 @@ export interface CardType {
   };
 
   img: ImageType;
+
+  imgResponsive: {
+    width1335: number;
+    height1335: number;
+    width600: number;
+    height600: number;
+    right1335: string;
+    right600: string;
+  };
 }
 
 const CurriculumArray: CardType[] = [
@@ -42,6 +53,14 @@ const CurriculumArray: CardType[] = [
       width: 234,
       height: 220,
     },
+    imgResponsive: {
+      width1335: 286,
+      height1335: 242,
+      width600: 217,
+      height600: 199,
+      right1335: '3.6875rem',
+      right600: '1.25rem',
+    },
   },
   {
     isSmall: false,
@@ -56,6 +75,14 @@ const CurriculumArray: CardType[] = [
       src: 'PieChartIcon',
       width: 290,
       height: 260,
+    },
+    imgResponsive: {
+      width1335: 294,
+      height1335: 284,
+      width600: 224,
+      height600: 220,
+      right1335: '2.5625rem',
+      right600: '1.375rem',
     },
   },
   {
@@ -72,6 +99,14 @@ const CurriculumArray: CardType[] = [
       width: 360,
       height: 252,
     },
+    imgResponsive: {
+      width1335: 346,
+      height1335: 266,
+      width600: 267,
+      height600: 210,
+      right1335: '2.4375rem',
+      right600: '1.6875rem',
+    },
   },
   {
     isSmall: true,
@@ -87,49 +122,88 @@ const CurriculumArray: CardType[] = [
       width: 240,
       height: 220,
     },
+    imgResponsive: {
+      width1335: 276,
+      height1335: 240,
+      width600: 246,
+      height600: 214,
+      right1335: '1.875rem',
+      right600: '0',
+    },
   },
 ];
 
-const CurriculumCards = () => (
-  <S.SectionCardWrapper>
-    {CurriculumArray.map((card, cardIndex) => (
-      <S.CardTemplate
-        key={cardIndex}
-        css={css`
-          width: ${card.isSmall ? '30.9375rem' : '44.6875rem'};
-          background-color: ${card.bgColor};
-        `}
-      >
-        <S.CardTitle
-          css={css`
-            color: ${card.color};
+const CurriculumCards = () => {
+  const width = useGetWindowWidth();
 
-            span {
-              color: ${card.color};
-              opacity: 60%;
-            }
-          `}
-        >
-          {card.title}
-          <br />
-          <span>{card.subTitle}</span>
-        </S.CardTitle>
-        <S.CardImg
+  const handleResponsiveImg = (card: CardType) => {
+    if (width > 1335) {
+      return {
+        width: card.img.width,
+        height: card.img.height,
+        right: card.cardPosition.right,
+      };
+    } else if (width <= 1335 && width > 600) {
+      return {
+        width: card.imgResponsive.width1335,
+        height: card.imgResponsive.height1335,
+        right: card.imgResponsive.right1335,
+      };
+    } else {
+      return {
+        width: card.imgResponsive.width600,
+        height: card.imgResponsive.height600,
+        right: card.imgResponsive.right600,
+      };
+    }
+  };
+
+  return (
+    <S.SectionCardWrapper>
+      {CurriculumArray.map((card, cardIndex) => (
+        <S.CardTemplate
+          key={cardIndex}
           css={css`
-            bottom: 0;
-            right: ${card.cardPosition.right};
+            width: ${width > 1335
+              ? card.isSmall
+                ? '30.9375rem'
+                : '44.6875rem'
+              : '100%'};
+
+            background-color: ${card.bgColor};
           `}
         >
-          <Image
-            src={`/images/about/section4/${card.img.src}.png`}
-            width={card.img.width}
-            height={card.img.height}
-            alt='교육과정 이미지'
-          />
-        </S.CardImg>
-      </S.CardTemplate>
-    ))}
-  </S.SectionCardWrapper>
-);
+          <S.CardTitle
+            css={css`
+              color: ${card.color};
+
+              span {
+                color: ${card.color};
+                opacity: 60%;
+              }
+            `}
+          >
+            {card.title}
+            <br />
+            <span>{card.subTitle}</span>
+          </S.CardTitle>
+          <S.CardImg
+            css={css`
+              bottom: 0;
+              right: ${handleResponsiveImg(card).right};
+            `}
+          >
+            <Image
+              src={`/images/about/section4/${card.img.src}.png`}
+              width={handleResponsiveImg(card).width}
+              height={handleResponsiveImg(card).height}
+              alt='교육과정 이미지'
+            />
+          </S.CardImg>
+        </S.CardTemplate>
+      ))}
+    </S.SectionCardWrapper>
+  );
+};
 
 export default CurriculumCards;

--- a/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
+++ b/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
@@ -189,13 +189,23 @@ const CurriculumCards = () => {
           <S.CardImg
             css={css`
               bottom: 0;
-              right: ${handleResponsiveImg(card).right};
+              right: ${card.cardPosition.right};
+
+              @media (max-width: 1335px) {
+                right: ${handleResponsiveImg(card).right};
+              }
             `}
           >
             <Image
               src={`/images/about/section4/${card.img.src}.png`}
-              width={handleResponsiveImg(card).width}
-              height={handleResponsiveImg(card).height}
+              width={card.img.width}
+              height={card.img.height}
+              css={css`
+                @media (max-width: 1335px) {
+                  width: ${handleResponsiveImg(card).width};
+                  height: ${handleResponsiveImg(card).height};
+                }
+              `}
               alt='교육과정 이미지'
             />
           </S.CardImg>

--- a/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
+++ b/apps/client/src/components/About/Section4/CurriculumCards/index.tsx
@@ -164,12 +164,11 @@ const CurriculumCards = () => {
         <S.CardTemplate
           key={cardIndex}
           css={css`
-            width: ${width > 1335
-              ? card.isSmall
-                ? '30.9375rem'
-                : '44.6875rem'
-              : '100%'};
+            width: ${card.isSmall ? '30.9375rem' : '44.6875rem'};
 
+            @media (max-width: 1335px) {
+              width: 100%;
+            }
             background-color: ${card.bgColor};
           `}
         >

--- a/apps/client/src/components/About/Section4/CurriculumCards/style.ts
+++ b/apps/client/src/components/About/Section4/CurriculumCards/style.ts
@@ -7,6 +7,7 @@ export const SectionCardWrapper = styled.div`
 `;
 
 export const CardTemplate = styled.div`
+  overflow: hidden;
   height: 21.6875rem;
   border-radius: 1.875rem;
   position: relative;

--- a/apps/client/src/components/About/Section4/style.ts
+++ b/apps/client/src/components/About/Section4/style.ts
@@ -6,6 +6,10 @@ export const SectionWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+
+  @media (max-width: 1335px) {
+    height: 2039px;
+  }
 `;
 
 export const SectionContentWrapper = styled.div`
@@ -15,4 +19,14 @@ export const SectionContentWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
+
+  @media (max-width: 1335px) {
+    width: 824px;
+    height: 1679px;
+  }
+
+  @media (${({ theme }) => theme.breakPoint[600]}) {
+    width: 480px;
+    height: 1618px;
+  }
 `;

--- a/apps/client/src/components/About/Section4/style.ts
+++ b/apps/client/src/components/About/Section4/style.ts
@@ -7,8 +7,13 @@ export const SectionWrapper = styled.div`
   justify-content: center;
   align-items: center;
 
-  @media${({ theme }) => theme.breakPoint[1440]} {
+  @media ${({ theme }) => theme.breakPoint[1440]} {
     height: 127.4375rem;
+  }
+
+  @media ${({ theme }) => theme.breakPoint[600]} {
+    width: calc(100vw - 120px);
+    margin: 0 auto;
   }
 `;
 

--- a/apps/client/src/components/About/Section4/style.ts
+++ b/apps/client/src/components/About/Section4/style.ts
@@ -21,7 +21,7 @@ export const SectionContentWrapper = styled.div`
   justify-content: space-between;
 
   @media (max-width: 1335px) {
-    width: 824px;
+    width: 51.5rem;
     height: 104.9375rem;
   }
 

--- a/apps/client/src/components/About/Section4/style.ts
+++ b/apps/client/src/components/About/Section4/style.ts
@@ -7,7 +7,7 @@ export const SectionWrapper = styled.div`
   justify-content: center;
   align-items: center;
 
-  @media (max-width: 1335px) {
+  @media (max-width: 1440px) {
     height: 127.4375rem;
   }
 `;
@@ -20,7 +20,7 @@ export const SectionContentWrapper = styled.div`
   align-items: center;
   justify-content: space-between;
 
-  @media (max-width: 1335px) {
+  @media (max-width: 1440px) {
     width: 51.5rem;
     height: 104.9375rem;
   }

--- a/apps/client/src/components/About/Section4/style.ts
+++ b/apps/client/src/components/About/Section4/style.ts
@@ -8,7 +8,7 @@ export const SectionWrapper = styled.div`
   align-items: center;
 
   @media (max-width: 1335px) {
-    height: 2039px;
+    height: 127.4375rem;
   }
 `;
 
@@ -22,11 +22,11 @@ export const SectionContentWrapper = styled.div`
 
   @media (max-width: 1335px) {
     width: 824px;
-    height: 1679px;
+    height: 104.9375rem;
   }
 
-  @media (${({ theme }) => theme.breakPoint[600]}) {
-    width: 480px;
-    height: 1618px;
+  @media ${({ theme }) => theme.breakPoint[600]} {
+    width: 30rem;
+    height: 101.125rem;
   }
 `;

--- a/apps/client/src/components/About/Section4/style.ts
+++ b/apps/client/src/components/About/Section4/style.ts
@@ -12,7 +12,7 @@ export const SectionWrapper = styled.div`
   }
 
   @media ${({ theme }) => theme.breakPoint[600]} {
-    width: calc(100vw - 120px);
+    width: calc(100vw - 7.5rem);
     margin: 0 auto;
   }
 `;

--- a/apps/client/src/components/About/Section4/style.ts
+++ b/apps/client/src/components/About/Section4/style.ts
@@ -7,7 +7,7 @@ export const SectionWrapper = styled.div`
   justify-content: center;
   align-items: center;
 
-  @media (max-width: 1440px) {
+  @media${({ theme }) => theme.breakPoint[1440]} {
     height: 127.4375rem;
   }
 `;
@@ -20,7 +20,7 @@ export const SectionContentWrapper = styled.div`
   align-items: center;
   justify-content: space-between;
 
-  @media (max-width: 1440px) {
+  @media ${({ theme }) => theme.breakPoint[1440]} {
     width: 51.5rem;
     height: 104.9375rem;
   }


### PR DESCRIPTION
## 개요 💡

section4 반응형 추가

## 작업내용 ⌨️

+ Section4 반응형
+ 디자인은 1024px일 때 스타일이 바뀌지만, 1300대부터 크기가 망가지기에 1335px부터 반응형 스타일을 적용시켰습니다.

+ 1335

<img width="910" alt="스크린샷 2023-07-08 오후 9 43 50" src="https://github.com/themoment-team/official-gsm-front/assets/103944346/65cf1501-1e04-4150-9a39-399cc6b38fe8">

+ 600
 
<img width="511" alt="스크린샷 2023-07-08 오후 9 46 19" src="https://github.com/themoment-team/official-gsm-front/assets/103944346/bcea096c-ee41-4fb8-8215-f8432534641f">


## 의논하고싶은부분
1335일때와 600일때 이미지크기와 position right값이 다 달라서
 CurriculumArray가 너무 혼잡합니다. 줄일수 있는방법에대해 의논하고싶습니다
