### PR TITLE
[Client] Update PromotionVideo style

### DIFF
--- a/apps/client/src/app/page.tsx
+++ b/apps/client/src/app/page.tsx
@@ -12,22 +12,15 @@ import {
   NoticeBanner,
   GalleryList,
 } from 'client/components';
-import { useGetWindowScrollHeight, useGetWindowWidth } from 'client/hooks';
+import { useGetWindowScrollHeight, useGetWindowHeight } from 'client/hooks';
 
 const headerHeightPx = 64;
 
 export default function Home() {
   const windowScrollHeight = useGetWindowScrollHeight();
-  const windowWidth = useGetWindowWidth();
+  const windowHeight = useGetWindowHeight();
 
-  const isTablet = windowWidth < 1024;
-
-  // TODO: 1rem의 px 값을 가져오는 hook 제작
-
-  /** 가로 : 세로 = 16 : 9 = 100 : 56.25 (56.25%) */
-  const promotionVideoHeightPx = isTablet ? 700 : (windowWidth / 100) * 56.25;
-
-  const videoOverlayPx = promotionVideoHeightPx - headerHeightPx;
+  const videoOverlayPx = windowHeight - headerHeightPx;
 
   const isBackgroundWhite = windowScrollHeight > videoOverlayPx;
 
@@ -54,10 +47,6 @@ const Content = styled.div`
   flex-direction: column;
   align-items: center;
   z-index: 1;
-  margin-top: calc(56.25vw - 4rem);
+  margin-top: calc(100vh - 4rem);
   padding: 6.25rem 0 12.5rem;
-
-  @media ${({ theme }) => theme.breakPoint['1024']} {
-    margin-top: calc(43.75rem - 4rem);
-  }
 `;

--- a/apps/client/src/components/PromotionVideo/index.tsx
+++ b/apps/client/src/components/PromotionVideo/index.tsx
@@ -2,7 +2,7 @@ import * as S from './style';
 
 const PromotionVideo = () => (
   <S.VidoeWrapper>
-    <S.Video src='/video/promotion.webm' autoPlay loop muted />
+    <S.Video src='/video/promotion.mp4' autoPlay loop muted playsInline />
     <S.VideoCover />
   </S.VidoeWrapper>
 );

--- a/apps/client/src/components/PromotionVideo/style.ts
+++ b/apps/client/src/components/PromotionVideo/style.ts
@@ -2,35 +2,25 @@ import styled from '@emotion/styled';
 
 export const VidoeWrapper = styled.div`
   width: 100%;
+  height: 100vh;
   position: fixed;
   top: 0;
   z-index: 0;
-
-  @media ${({ theme }) => theme.breakPoint['1024']} {
-    height: 43.75rem;
-    display: flex;
-    justify-content: center;
-  }
+  display: flex;
+  justify-content: center;
 `;
 
 export const Video = styled.video`
   width: 100%;
-
-  @media ${({ theme }) => theme.breakPoint['1024']} {
-    width: auto;
-    height: 100%;
-  }
+  height: 100%;
+  object-fit: cover;
 `;
 
 export const VideoCover = styled.div`
   width: 100%;
-  height: calc(56.25vw);
+  height: 100vh;
   background: rgba(0, 0, 0, 0.5);
   position: absolute;
   top: 0;
   z-index: 2;
-
-  @media ${({ theme }) => theme.breakPoint['1024']} {
-    height: 43.75rem;
-  }
 `;

--- a/apps/client/src/components/SlotMachine/style.ts
+++ b/apps/client/src/components/SlotMachine/style.ts
@@ -53,9 +53,9 @@ export const SlotMachineAnimation = styled.div`
   font-size: 6.2376rem;
   color: ${({ theme }) => theme.color.white};
   position: fixed;
-  top: 21.625rem;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
 `;
 
 export const ListWrap = styled.div`

--- a/apps/client/src/hooks/index.ts
+++ b/apps/client/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useGetScrollHeight } from './useGetScrollHeight';
+export { default as useGetWindowHeight } from './useGetWindowHeight';
 export { default as useGetWindowScrollHeight } from './useGetWindowScrollHeight';
 export { default as useGetWindowWidth } from './useGetWindowWidth';

--- a/apps/client/src/hooks/useGetWindowHeight.ts
+++ b/apps/client/src/hooks/useGetWindowHeight.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * viewport의 height 값을 가져옵니다.
+ * @returns windowHeight: number(단위 px)
+ */
+export default function useGetWindowHeight() {
+  const [windowHeight, setWindowHeight] = useState<number>(1080);
+
+  let throttling = false;
+
+  function onResize() {
+    if (throttling) return;
+
+    throttling = true;
+
+    setTimeout(() => {
+      setWindowHeight(window.innerHeight);
+      throttling = false;
+    }, 200);
+  }
+
+  useEffect(() => {
+    setWindowHeight(window.innerHeight);
+
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      window.removeEventListener('resize', onResize);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return windowHeight;
+}


### PR DESCRIPTION
## 개요 💡

> 메인 페이지 내의 PromotionVideo의 style을 변경하였습니다.

## 작업내용 ⌨️

- promotion video의 height를 항시 100vh로 변경하였습니다
- video의 확장자를 `.webm -> .mp4 `로 변경하였습니다.
  - ios의 webkit에서 `.webm` 확장자를 지원하지 않습니다 
  - https://caniuse.com/webm

<img width="300" alt="스크린샷 2023-07-12 오전 12 29 38" src="https://github.com/themoment-team/official-gsm-front/assets/80103328/525cb5d2-755c-4000-b949-e1e48acac94a">
<img width="300" alt="스크린샷 2023-07-12 오전 12 29 51" src="https://github.com/themoment-team/official-gsm-front/assets/80103328/7a6f9c35-679b-4776-81e0-fd5be7ac8fbc">


## TODO

- os에 따라 video 확장자 변경
- width에 따라 video 해상도 조절 (video 용량 최적화)