### PR TITLE
[Client] Fix for ios

### DIFF
--- a/apps/client/src/components/HamburgerMenu/BackgroundBalls/style.ts
+++ b/apps/client/src/components/HamburgerMenu/BackgroundBalls/style.ts
@@ -13,6 +13,7 @@ export const Ball = styled.div`
   border-radius: 100%;
   position: absolute;
   filter: blur(6.25rem);
+  transform: translate3d(0, 0, 0);
 `;
 
 export const Ball1 = styled(Ball)`

--- a/apps/client/src/components/HamburgerMenu/BackgroundBalls/style.ts
+++ b/apps/client/src/components/HamburgerMenu/BackgroundBalls/style.ts
@@ -13,7 +13,7 @@ export const Ball = styled.div`
   border-radius: 100%;
   position: absolute;
   filter: blur(6.25rem);
-  transform: translate3d(0, 0, 0);
+  will-change: filter;
 `;
 
 export const Ball1 = styled(Ball)`

--- a/apps/client/src/components/HamburgerMenu/style.ts
+++ b/apps/client/src/components/HamburgerMenu/style.ts
@@ -17,16 +17,14 @@ export const HamburgerMenu = styled.div<{
 }>`
   width: 28.75rem;
   height: 100vh;
-  position: absolute;
-  right: 0;
+  position: fixed;
+  top: 0;
+  right: ${({ isHamburgerMenuShow }) => (isHamburgerMenuShow ? 0 : '-100%')};
   background: ${({ theme }) => theme.color.white};
   z-index: 1;
   padding-top: 5rem;
   padding-left: 3.13rem;
-  transform: translateX(100%);
-  transition: transform 0.5s ease-in-out;
-  transform: ${({ isHamburgerMenuShow }) =>
-    isHamburgerMenuShow && 'translateX(0)'};
+  transition: right 0.5s ease-in-out;
 `;
 
 export const HamburgerNav = styled.nav`

--- a/apps/client/src/components/HamburgerMenu/style.ts
+++ b/apps/client/src/components/HamburgerMenu/style.ts
@@ -19,7 +19,8 @@ export const HamburgerMenu = styled.div<{
   height: 100vh;
   position: fixed;
   top: 0;
-  right: ${({ isHamburgerMenuShow }) => (isHamburgerMenuShow ? 0 : '-100%')};
+  right: ${({ isHamburgerMenuShow }) =>
+    isHamburgerMenuShow ? 0 : '-28.75rem'};
   background: ${({ theme }) => theme.color.white};
   z-index: 1;
   padding-top: 5rem;

--- a/apps/client/src/components/MainPage/Content/index.tsx
+++ b/apps/client/src/components/MainPage/Content/index.tsx
@@ -27,10 +27,6 @@ const Content = styled.div`
   flex-direction: column;
   align-items: center;
   z-index: 1;
-  margin-top: calc(56.25vw - 4rem);
+  margin-top: calc(100vh - 4rem);
   padding: 6.25rem 0 12.5rem;
-
-  @media ${({ theme }) => theme.breakPoint['1024']} {
-    margin-top: calc(43.75rem - 4rem);
-  }
 `;

--- a/apps/client/src/components/MainPage/Header/index.tsx
+++ b/apps/client/src/components/MainPage/Header/index.tsx
@@ -1,22 +1,16 @@
 'use client';
 
 import { Header } from 'client/components';
-import { useGetWindowScrollHeight, useGetWindowWidth } from 'client/hooks';
+import { useGetWindowHeight, useGetWindowScrollHeight } from 'client/hooks';
 
 const headerHeightPx = 64;
 
 const MainpageHeader = () => {
   const windowScrollHeight = useGetWindowScrollHeight();
-  const windowWidth = useGetWindowWidth();
+  const windowHeight = useGetWindowHeight();
 
-  const isTablet = windowWidth <= 1024;
+  const videoOverlayPx = windowHeight - headerHeightPx;
 
-  /** 가로 : 세로 = 16 : 9 = 100 : 56.25 (56.25%) */
-  const promotionVideoHeightPx = isTablet ? 700 : (windowWidth / 100) * 56.25;
-
-  const videoOverlayPx = promotionVideoHeightPx - headerHeightPx;
-
-  // main과 분리
   const isAbovePromotionVideo = windowScrollHeight < videoOverlayPx;
 
   return <Header segment='' isAbovePromotionVideo={isAbovePromotionVideo} />;


### PR DESCRIPTION
## 개요 💡

> ios webkit에서 호환되지 않거나, 낮은 퍼포먼스를 보여주는 부분들을 개선했습니다.

## 작업내용 ⌨️

- conflict 해결 당시, 누락되어 버린 PromotionVideo 관련 position 재 복구

### 모바일에서의 issue

모바일에서 body의 `overflow-x: hidden`이 적용되지 않음

- **해결 - `position: fixed`와 `right` 속성 이용하여 애니메이션 구현 202fc783939de012a9a34d02504fde790da271ac**

- 다른 해결 방법 - html, body 에 아래와 같이 속성을 줍니다.
  - ```css
     html, body {
       overflow-x: hidden
     }
      ```
  - 하지만, 위 방식 사용 시 header의 `position: sticky`가 적용되지 않습니다
  

### ios webkit 관련 issue

- ios webkit에서 낮은 퍼포먼스를 보여주던 `filter: blur()`를 위한 [`will-change: filter;`](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change) 코드 추가
- 해당 속성으로 하드웨어 가속을 하였습니다.

before

https://github.com/themoment-team/official-gsm-front/assets/80103328/f5494dff-7fd1-43b6-a665-caec4e5e6777

after

https://github.com/themoment-team/official-gsm-front/assets/80103328/45ed6deb-d6db-4fcb-84ab-b8ab3d155845