### PR TITLE
[Client] Add notFound() in post detail

### DIFF
--- a/apps/client/src/app/post/[postSeq]/page.tsx
+++ b/apps/client/src/app/post/[postSeq]/page.tsx
@@ -1,3 +1,5 @@
+import { notFound } from 'next/navigation';
+
 import { Footer, Header, AssembledPost } from 'client/components';
 
 import { postUrl } from 'api/client';
@@ -28,6 +30,8 @@ export const generateMetadata = async ({
   const post: Promise<PostDetailType> = await fetch(
     `${process.env.BASE_URL}/api/client${postUrl.postDetail(postSeq)}`
   ).then((res) => res.json());
+
+  if (!(await post).postTitle) return notFound();
 
   return {
     title: { absolute: (await post).postTitle },

--- a/apps/client/src/app/post/[postSeq]/page.tsx
+++ b/apps/client/src/app/post/[postSeq]/page.tsx
@@ -25,23 +25,25 @@ export default function PostPage({ params: { postSeq } }: PostPageProps) {
 export const generateMetadata = async ({
   params,
 }: PostPageProps): Promise<Metadata> => {
-  const postSeq = Number(params.postSeq);
+  try {
+    const postSeq = Number(params.postSeq);
 
-  const post: PostDetailType = await fetch(
-    `${process.env.BASE_URL}/api/client${postUrl.postDetail(postSeq)}`
-  ).then((res) => res.json());
+    const post: PostDetailType = await fetch(
+      `${process.env.BASE_URL}/api/client${postUrl.postDetail(postSeq)}`
+    ).then((res) => res.json());
 
-  if (!post.postTitle) return notFound();
-
-  return {
-    title: { absolute: post.postTitle },
-    description: descriptionFormatting(post.postContent),
-    openGraph: {
-      title: post.postTitle,
+    return {
+      title: { absolute: post.postTitle },
       description: descriptionFormatting(post.postContent),
-      url: `https://official.hellogsm.kr/post/${postSeq}`,
-    },
-  };
+      openGraph: {
+        title: post.postTitle,
+        description: descriptionFormatting(post.postContent),
+        url: `https://official.hellogsm.kr/post/${postSeq}`,
+      },
+    };
+  } catch (e) {
+    return notFound();
+  }
 };
 
 const descriptionFormatting = (description: string) =>

--- a/apps/client/src/app/post/[postSeq]/page.tsx
+++ b/apps/client/src/app/post/[postSeq]/page.tsx
@@ -27,19 +27,22 @@ export const generateMetadata = async ({
 }: PostPageProps): Promise<Metadata> => {
   const postSeq = Number(params.postSeq);
 
-  const post: Promise<PostDetailType> = await fetch(
+  const post: PostDetailType = await fetch(
     `${process.env.BASE_URL}/api/client${postUrl.postDetail(postSeq)}`
   ).then((res) => res.json());
 
-  if (!(await post).postTitle) return notFound();
+  if (!post.postTitle) return notFound();
 
   return {
-    title: { absolute: (await post).postTitle },
-    description: (await post).postContent,
+    title: { absolute: post.postTitle },
+    description: descriptionFormatting(post.postContent),
     openGraph: {
-      title: (await post).postTitle,
-      description: (await post).postContent,
+      title: post.postTitle,
+      description: descriptionFormatting(post.postContent),
       url: `https://official.hellogsm.kr/post/${postSeq}`,
     },
   };
 };
+
+const descriptionFormatting = (description: string) =>
+  description.replace(/\n/g, ' ').replace(/\s+/g, ' ').slice(0, 120);

--- a/apps/client/src/assets/svg/NotFoundTitle.tsx
+++ b/apps/client/src/assets/svg/NotFoundTitle.tsx
@@ -27,7 +27,7 @@ const NotFoundTitle = () => (
         y2='328.025'
         gradientUnits='userSpaceOnUse'
       >
-        <stop stop-color='#B2E449' />
+        <stop stopColor='#B2E449' />
         <stop offset='0.488435' stopColor='#7ACDF4' />
         <stop offset='0.614583' stopColor='#5CA7D1' />
         <stop offset='1' stopColor='#003365' />
@@ -40,7 +40,7 @@ const NotFoundTitle = () => (
         y2='328.025'
         gradientUnits='userSpaceOnUse'
       >
-        <stop stop-color='#B2E449' />
+        <stop stopColor='#B2E449' />
         <stop offset='0.488435' stopColor='#7ACDF4' />
         <stop offset='0.614583' stopColor='#5CA7D1' />
         <stop offset='1' stopColor='#003365' />

--- a/apps/client/src/components/PostPage/AssembledPost/index.tsx
+++ b/apps/client/src/components/PostPage/AssembledPost/index.tsx
@@ -2,6 +2,8 @@
 
 'use client';
 
+import { notFound } from 'next/navigation';
+
 import { css } from '@emotion/react';
 
 import { PostContent, PostDetailHead, ReturnToList } from 'client/components';
@@ -17,7 +19,9 @@ interface AssembledPostProps {
 }
 
 const AssembledPost: React.FC<AssembledPostProps> = ({ postSeq }) => {
-  const { data } = useGetPostDetail(postSeq);
+  const { data, isError } = useGetPostDetail(postSeq);
+
+  if (isError) notFound();
 
   return (
     <S.BackGround>

--- a/apps/client/src/components/PostPage/AssembledPost/index.tsx
+++ b/apps/client/src/components/PostPage/AssembledPost/index.tsx
@@ -2,8 +2,6 @@
 
 'use client';
 
-import { notFound } from 'next/navigation';
-
 import { css } from '@emotion/react';
 
 import { PostContent, PostDetailHead, ReturnToList } from 'client/components';
@@ -19,9 +17,7 @@ interface AssembledPostProps {
 }
 
 const AssembledPost: React.FC<AssembledPostProps> = ({ postSeq }) => {
-  const { data, isError } = useGetPostDetail(postSeq);
-
-  if (isError) notFound();
+  const { data } = useGetPostDetail(postSeq);
 
   return (
     <S.BackGround>


### PR DESCRIPTION
## 개요 💡

> 존재하지 않는 게시글 조회 시, 404 페이지를 보여줍니다

## 작업내용 ⌨️

- `generateMetadata()` 내부에서, 게시글 조회 에러 발생 시, 404 페이지를 보여줍니다
- `descriptionFormatting` 으로 description 글자 수 제한을 120자로 설정했습니다.
  - `.replace(/\n/g, ' ')` - 개행 문자 -> ' ' (1칸 공백)
  - `.replace(/\s+/g, ' ')` - 2칸 이상의 공백 -> ' ' (1칸 공백)

before
<img width="800" alt="스크린샷 2023-08-02 오전 7 19 08" src="https://github.com/themoment-team/official-gsm-front/assets/80103328/28ea0d7d-e134-412b-8cc5-76134fcd4da2">

after
<img width="800" alt="스크린샷 2023-08-02 오전 7 12 56" src="https://github.com/themoment-team/official-gsm-front/assets/80103328/17a7ae9a-ac14-4da7-a5f1-4ae26ab9d603">
