### PR TITLE
[Client] useScroollToTop

### DIFF
--- a/apps/client/src/components/Header/index.tsx
+++ b/apps/client/src/components/Header/index.tsx
@@ -10,6 +10,7 @@ import { css, useTheme } from '@emotion/react';
 
 import { HamburgerIcon, HeaderGSMLogo } from 'client/assets';
 import { HamburgerMenu } from 'client/components';
+import { useScrollToTop } from 'client/hooks';
 import { useGetWindowWidth } from 'client/hooks';
 
 import * as S from './style';
@@ -25,6 +26,8 @@ const Header: React.FC<HeaderProps> = ({
   segment,
   isAbovePromotionVideo = false,
 }) => {
+  useScrollToTop();
+
   const [isHamburgerMenuShow, setIsHamburgerMenuShow] =
     useState<boolean>(false);
 

--- a/apps/client/src/hooks/index.ts
+++ b/apps/client/src/hooks/index.ts
@@ -2,3 +2,4 @@ export { default as useGetScrollHeight } from './useGetScrollHeight';
 export { default as useGetWindowHeight } from './useGetWindowHeight';
 export { default as useGetWindowScrollHeight } from './useGetWindowScrollHeight';
 export { default as useGetWindowWidth } from './useGetWindowWidth';
+export { default as useScrollToTop } from './useScrollToTop';

--- a/apps/client/src/hooks/useScrollToTop.ts
+++ b/apps/client/src/hooks/useScrollToTop.ts
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+
+/**
+ * window를 맨 위로 scroll합니다.
+ */
+export default function useScrollToTop() {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+}


### PR DESCRIPTION
## 개요 💡

> useScroollToTop hook을 제작했습니다.

## 작업내용 ⌨️

> Link Tag를 사용하여 페이지 이동시 `scroll={true}`를 설정하여도 스크롤이 top으로 이동하지 않아 이동하게끔 하는 hook을 제작하였습니다.

시온선배님께서 공유해주신 관련 issue 첨부합니다.
https://github.com/vercel/next.js/issues/42492
