### PR TITLE
[Client] Improve post detail page

### DIFF
--- a/apps/client/src/app/post/[postSeq]/page.tsx
+++ b/apps/client/src/app/post/[postSeq]/page.tsx
@@ -4,6 +4,8 @@ import { Footer, Header, AssembledPost } from 'client/components';
 
 import { postUrl } from 'api/client';
 
+import { descriptionFormatting } from 'common';
+
 import type { PostDetailType } from 'types';
 
 import type { Metadata } from 'next';
@@ -12,11 +14,13 @@ interface PostPageProps {
   params: { postSeq: string };
 }
 
-export default function PostPage({ params: { postSeq } }: PostPageProps) {
+export default async function PostPage({ params: { postSeq } }: PostPageProps) {
+  const post = await getPostDetail(parseInt(postSeq));
+
   return (
     <>
       <Header segment='list' />
-      <AssembledPost postSeq={parseInt(postSeq)} />
+      <AssembledPost post={post} postSeq={parseInt(postSeq)} />
       <Footer />
     </>
   );
@@ -28,9 +32,7 @@ export const generateMetadata = async ({
   try {
     const postSeq = Number(params.postSeq);
 
-    const post: PostDetailType = await fetch(
-      `${process.env.BASE_URL}/api/client${postUrl.postDetail(postSeq)}`
-    ).then((res) => res.json());
+    const post = await getPostDetail(postSeq);
 
     return {
       title: { absolute: post.postTitle },
@@ -46,5 +48,17 @@ export const generateMetadata = async ({
   }
 };
 
-const descriptionFormatting = (description: string) =>
-  description.replace(/\n/g, ' ').replace(/\s+/g, ' ').slice(0, 120);
+async function getPostDetail(postSeq: number) {
+  const res = await fetch(
+    `${process.env.CLIENT_API_URL}/api${postUrl.postDetail(postSeq)}`,
+    {
+      next: {
+        revalidate: 60,
+      },
+    }
+  );
+
+  const data: PostDetailType = await res.json();
+
+  return data;
+}

--- a/apps/client/src/app/post/[postSeq]/page.tsx
+++ b/apps/client/src/app/post/[postSeq]/page.tsx
@@ -50,7 +50,7 @@ export const generateMetadata = async ({
 
 async function getPostDetail(postSeq: number) {
   const res = await fetch(
-    `${process.env.CLIENT_API_URL}/api${postUrl.postDetail(postSeq)}`,
+    `${process.env.BASE_URL}/api/client${postUrl.postDetail(postSeq)}`,
     {
       next: {
         revalidate: 60,

--- a/apps/client/src/components/PostPage/AssembledPost/index.tsx
+++ b/apps/client/src/components/PostPage/AssembledPost/index.tsx
@@ -10,14 +10,19 @@ import { useGetPostDetail } from 'api/client';
 
 import { FileButton } from 'ui';
 
+import type { PostDetailType } from 'types';
+
 import * as S from './style';
 
 interface AssembledPostProps {
+  post: PostDetailType;
   postSeq: number;
 }
 
-const AssembledPost: React.FC<AssembledPostProps> = ({ postSeq }) => {
-  const { data } = useGetPostDetail(postSeq);
+const AssembledPost: React.FC<AssembledPostProps> = ({ postSeq, post }) => {
+  const { data } = useGetPostDetail(postSeq, {
+    initialData: post,
+  });
 
   return (
     <S.BackGround>

--- a/apps/client/src/components/PostPage/PostDetailHead/index.tsx
+++ b/apps/client/src/components/PostPage/PostDetailHead/index.tsx
@@ -18,6 +18,7 @@ const categoryTitle = {
 
 const PostDetailHead: React.FC<PostDetailHeadProps> = ({ postSeq }) => {
   const { data } = useGetPostDetail(postSeq);
+
   return (
     <>
       {data && (
@@ -34,4 +35,5 @@ const PostDetailHead: React.FC<PostDetailHeadProps> = ({ postSeq }) => {
     </>
   );
 };
+
 export default PostDetailHead;

--- a/packages/api/client/src/hooks/api/post/useGetPostDetail.ts
+++ b/packages/api/client/src/hooks/api/post/useGetPostDetail.ts
@@ -13,5 +13,5 @@ export const useGetPostDetail = (
   useQuery<PostDetailType>(
     postQueryKeys.getPostDetail(seq),
     () => get(postUrl.postDetail(seq)),
-    options
+    { staleTime: 1000, ...options }
   );

--- a/packages/common/src/utils/descriptionFormatting.ts
+++ b/packages/common/src/utils/descriptionFormatting.ts
@@ -1,0 +1,4 @@
+const descriptionFormatting = (description: string) =>
+  description.replace(/\n/g, ' ').replace(/\s+/g, ' ').slice(0, 120);
+
+export default descriptionFormatting;

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -3,3 +3,4 @@ export { default as formatDate } from './formatDate';
 export { default as secondsToMs } from './secondsToMs';
 export { default as pxToRem } from './pxToRem';
 export { default as filterImages } from './filterImages';
+export { default as descriptionFormatting } from './descriptionFormatting';


### PR DESCRIPTION
## 개요 💡

> server side에서 data fetching을 하여, fp -> fcp 및 fcp를 개선하였습니다.

## 작업내용 ⌨️

기존 client side에서 fetching 해오던 게시글 상세 api를 server side에서 fetching 하도록 변경하였습니다.

- server side fetching
  1. [fetch api](https://nextjs.org/docs/app/api-reference/functions/fetch)를 사용하여, server 단에서 data fetching을 합니다.
     - [revalidate](https://nextjs.org/docs/app/api-reference/functions/fetch#optionsnextrevalidate)를 적용하여, server에서 caching을 하여 유저가 페이지 조회 시마다 api 응답 대기를 할 필요 없이 바로 페이지를 볼 수 있고, 60초 마다 새롭게 캐싱됩니다.
  2. 해당 data를 client component인 AssembledPost에 prop으로 넘겨줍니다.
  3. AssembledPost에서 사용되는 useGetPostDetail hook의 option으로 넘겨받은 prop을 initialData에 할당합니다.
- useGetPostDetail - client side에서의 불필요한 중복 fetching을 막기 위해 staleTime 적용

## 개선 

chrome Performance를 이용하여 같은 네트워크 환경에서 측정했습니다.

### fp(first paint)  -> lcp (Largest contentful paint)

#### before

**약 275ms**

<img width="400" alt="스크린샷 2023-08-17 오전 11 32 43" src="https://github.com/themoment-team/official-gsm-front/assets/80103328/6cfaf0c3-a794-4856-9cb1-640cc487edfd">
<img width="400" alt="스크린샷 2023-08-17 오전 11 32 33" src="https://github.com/themoment-team/official-gsm-front/assets/80103328/9d1a5537-51ca-400a-a73e-7fd3ad57b797">

#### after 

**0 ms**

<img width="400" alt="스크린샷 2023-08-17 오후 12 51 38" src="https://github.com/themoment-team/official-gsm-front/assets/80103328/c38c90f7-3457-40d8-9850-e3b0a5fe0195">
<img width="400" alt="스크린샷 2023-08-17 오후 12 51 30" src="https://github.com/themoment-team/official-gsm-front/assets/80103328/dbd44199-73d3-47c1-8ca1-506dcf4b1f61">

-----

### only lcp 

측정 시 마다 결과가 달라져 10번 평균으로 계산하겠습니다.

#### before

**평균 759.74 ms**

<img width="500" alt="스크린샷 2023-08-17 오전 11 32 33" src="https://github.com/themoment-team/official-gsm-front/assets/80103328/6e6be2d4-18d3-4e54-b67d-6cd28d0b46e5">

#### after

**평균 374.36 ms**

<img width="500" alt="스크린샷 2023-08-17 오후 12 51 30" src="https://github.com/themoment-team/official-gsm-front/assets/80103328/e485374d-91f0-418c-8816-da992e8b682c">

-----

### 요약

- fp -> lcp - 약 275ms -> **0 ms**
- lcp 개선 - 평균 759.74 ms -> **평균 374.36 ms** (약 50% 감소)