### PR TITLE
[Admin] fix edit post page

### DIFF
--- a/apps/admin/src/app/post/edit/[postSeq]/page.tsx
+++ b/apps/admin/src/app/post/edit/[postSeq]/page.tsx
@@ -52,7 +52,8 @@ export default function EditPage({ params: { postSeq } }: EditPageProps) {
   const { data } = useGetPostDetail(postSeq);
 
   const isGallery = category === 'EVENT_GALLERY';
-  const gallerySubmitDisabled = isGallery && files.length === 0;
+  const gallerySubmitDisabled =
+    isGallery && (files.length && prevFiles?.length) === 0;
 
   const {
     register,

--- a/apps/admin/src/app/post/edit/[postSeq]/page.tsx
+++ b/apps/admin/src/app/post/edit/[postSeq]/page.tsx
@@ -52,7 +52,7 @@ export default function EditPage({ params: { postSeq } }: EditPageProps) {
   const { data } = useGetPostDetail(postSeq);
 
   const isGallery = category === 'EVENT_GALLERY';
-  const gallerySubmitDisabled =
+  const galleryEditDisabled =
     isGallery && (files.length && prevFiles?.length) === 0;
 
   const {
@@ -241,7 +241,7 @@ export default function EditPage({ params: { postSeq } }: EditPageProps) {
             <Button
               width='22.5625rem'
               type='submit'
-              disabled={gallerySubmitDisabled}
+              disabled={galleryEditDisabled}
             >
               완료
             </Button>

--- a/apps/admin/src/app/post/edit/[postSeq]/page.tsx
+++ b/apps/admin/src/app/post/edit/[postSeq]/page.tsx
@@ -53,7 +53,7 @@ export default function EditPage({ params: { postSeq } }: EditPageProps) {
 
   const isGallery = category === 'EVENT_GALLERY';
   const galleryEditDisabled =
-    isGallery && (files.length && prevFiles?.length) === 0;
+    isGallery && (prevFiles?.length || files.length) === 0;
 
   const {
     register,

--- a/apps/admin/src/app/post/edit/[postSeq]/page.tsx
+++ b/apps/admin/src/app/post/edit/[postSeq]/page.tsx
@@ -52,8 +52,7 @@ export default function EditPage({ params: { postSeq } }: EditPageProps) {
   const { data } = useGetPostDetail(postSeq);
 
   const isGallery = category === 'EVENT_GALLERY';
-  const galleryEditDisabled =
-    isGallery && (prevFiles?.length || files.length) === 0;
+  const galleryEditDisabled = isGallery && !prevFiles?.length && !files.length;
 
   const {
     register,


### PR DESCRIPTION
## 개요 💡

관리자 페이지 행사갤러리 글 수정시 사진을 1개 이상 추가해야 수정이되는 오류를 개선하였습니다.

## 작업내용 ⌨️

기존에 있던 파일 또는 새로 추가한 파일길이중 하나라도 0이 아닐시 수정버튼이 활성화 되도록 조건을 수정하였습니다.
feb7c81
