### PR TITLE
[Client] Update postDetail image size

### DIFF
--- a/apps/client/src/components/PostPage/AssembledPost/index.tsx
+++ b/apps/client/src/components/PostPage/AssembledPost/index.tsx
@@ -36,7 +36,7 @@ const AssembledPost: React.FC<AssembledPostProps> = ({ postSeq, post }) => {
           }
         >
           <PostDetailHead postSeq={postSeq} />
-          {data.postContent && (
+          {(data.postContent || data.fileInfo.length > 0) && (
             <S.ContentWrapper>
               <PostContent postSeq={postSeq} />
               {data.fileInfo.length > 0 && (

--- a/apps/client/src/components/PostPage/PostContent/index.tsx
+++ b/apps/client/src/components/PostPage/PostContent/index.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import Image from 'next/image';
-
 import { useGetPostDetail } from 'api/client';
 
 import { filterImages } from 'common';
@@ -23,7 +21,7 @@ const PostContent: React.FC<PostContentProps> = ({ postSeq }) => {
         <S.ContentWrapper>
           {imageFiles.map((file, index) => (
             <S.ImageWrapper key={index}>
-              <Image src={file.fileUrl} alt={file.fileName} fill />
+              <S.ContentImage src={file.fileUrl} alt={file.fileName} fill />
             </S.ImageWrapper>
           ))}
           <S.ContentText>{data?.postContent}</S.ContentText>

--- a/apps/client/src/components/PostPage/PostContent/style.ts
+++ b/apps/client/src/components/PostPage/PostContent/style.ts
@@ -1,3 +1,5 @@
+import Image from 'next/image';
+
 import styled from '@emotion/styled';
 
 export const ContentWrapper = styled.div`
@@ -11,9 +13,12 @@ export const ContentWrapper = styled.div`
   }
 `;
 
+export const ContentImage = styled(Image)`
+  position: relative !important;
+`;
+
 export const ImageWrapper = styled.div`
   width: 50rem;
-  height: 30.375rem;
   overflow: hidden;
   position: relative;
   img {


### PR DESCRIPTION
## 개요 💡

> 게시물 상세 페이지 안의 이미지의 사이즈 규격을 변경했습니다.

## 작업내용 ⌨️

+ 이미지 사이즈 규격 변경 (width 고정, height free)
<img width="300" alt="image" src="https://github.com/themoment-team/official-gsm-front/assets/106712562/75fec617-8089-4af7-8d14-c25e1eb5ee4b">

+ postContent가 없는 경우 이미지 출력 개선
<img width="300" alt="image" src="https://github.com/themoment-team/official-gsm-front/assets/106712562/708016bc-57b2-4edd-8a84-c081c9cd2780">

