### PR TITLE
[Hotfix] Add cctv policy page Link

### DIFF
--- a/apps/client/src/components/Footer/index.tsx
+++ b/apps/client/src/components/Footer/index.tsx
@@ -23,7 +23,7 @@ const Footer = () => {
             </S.Copyright>
             <S.LinkWrapper>
               <Link href='/policy/privacy'>개인정보처리방침</Link>
-              <Link href='#'>영상정보처리기기운영·관리방침</Link>
+              <Link href='/policy/cctv'>영상정보처리기기운영·관리방침</Link>
               <Link href='/policy/copyright'>저작권신고 및 보호규정</Link>
               <Link href='/about/location'>찾아오시는 길</Link>
               <a href='https://admin.official.hellogsm.kr/'>관리자</a>


### PR DESCRIPTION
## 개요 💡

> footer에 누락된 [영상정보처리기기운영·관리방침](https://official.hellogsm.kr/policy/cctv) 페이지 링킹을 추가했습니다.

## 작업내용 ⌨️

> 영상정보처리기기운영·관리방침 페이지 링킹 추가

아래서 작동여부 확인 가능하십니다
https://test-official-gsm-client-git-hotfix-cctv-the-moment.vercel.app/