### PR TITLE
[Client] Add react query caching

### DIFF
--- a/apps/client/src/app/providers.tsx
+++ b/apps/client/src/app/providers.tsx
@@ -6,7 +6,7 @@ import { ThemeProvider } from '@emotion/react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-import { theme } from 'common';
+import { minutesToMs, theme } from 'common';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   // TODO: client api 연동 시, queryclient option 공유 가능하도록 구성 변경
@@ -16,6 +16,8 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         defaultOptions: {
           queries: {
             retry: false,
+            staleTime: minutesToMs(5),
+            cacheTime: minutesToMs(5),
           },
         },
       })

--- a/packages/api/client/src/hooks/api/post/useGetPostDetail.ts
+++ b/packages/api/client/src/hooks/api/post/useGetPostDetail.ts
@@ -13,5 +13,5 @@ export const useGetPostDetail = (
   useQuery<PostDetailType>(
     postQueryKeys.getPostDetail(seq),
     () => get(postUrl.postDetail(seq)),
-    { staleTime: 1000, ...options }
+    options
   );

--- a/packages/api/client/src/hooks/api/post/useGetPostList.ts
+++ b/packages/api/client/src/hooks/api/post/useGetPostList.ts
@@ -17,7 +17,7 @@ export const useGetPostList = (
   pageSize: number
 ) =>
   useQuery(
-    postQueryKeys.getPostList(category, pageNumber),
+    postQueryKeys.getPostList(category, pageNumber, pageSize),
     () => get<PostListType>(postUrl.postList(category, pageNumber, pageSize)),
     {
       keepPreviousData: true,

--- a/packages/api/client/src/libs/queryKeys.ts
+++ b/packages/api/client/src/libs/queryKeys.ts
@@ -1,11 +1,10 @@
 import type { CategoryQueryStringType } from 'types';
 
 export const postQueryKeys = {
-  getPostList: (category: CategoryQueryStringType, pageNumber: number) => [
-    'post',
-    'list',
-    category,
-    pageNumber,
-  ],
+  getPostList: (
+    category: CategoryQueryStringType,
+    pageNumber: number,
+    pageSize: number
+  ) => ['post', 'list', category, pageNumber, pageSize],
   getPostDetail: (postSeq: number) => ['post', 'detail', postSeq],
 } as const;


### PR DESCRIPTION
## 개요 💡

> react query의 caching 기능을 활용하기 위한 작업을 했습니다.

## 작업내용 ⌨️

- client 애플리케이션의 QueryClient에 default option으로 cacheTime과 staleTIme 추가
- getPostList의 query key 수정
- useGetPostDetail에 존재하던 staleTime 옵션 제거