### PR TITLE
[Hotfix] Add admission guide in GNB

### DIFF
--- a/apps/client/src/components/HamburgerMenu/index.tsx
+++ b/apps/client/src/components/HamburgerMenu/index.tsx
@@ -52,7 +52,14 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({
           <Link css={selectStyle('about')} href='/about'>
             학교소개
           </Link>
-          <a href='https://hellogsm.kr'>입학</a>
+          <a href='https://hellogsm.kr'>입학 접수</a>
+          <a
+            href='http://gsm.gen.hs.kr/sub/page.php?page_code=entrance_01'
+            target='_blank'
+            rel='noreferrer noopener'
+          >
+            입학 안내
+          </a>
         </S.HamburgerNav>
         <FooterGSMLogo isHamburger={true} />
         <BackgroundBall />

--- a/apps/client/src/components/Header/index.tsx
+++ b/apps/client/src/components/Header/index.tsx
@@ -84,7 +84,14 @@ const Header: React.FC<HeaderProps> = ({
             <Link css={selectStyle('about')} href='/about'>
               학교소개
             </Link>
-            <a href='https://hellogsm.kr'>입학</a>
+            <a href='https://hellogsm.kr'>입학 접수</a>
+            <a
+              href='http://gsm.gen.hs.kr/sub/page.php?page_code=entrance_01'
+              target='_blank'
+              rel='noreferrer noopener'
+            >
+              입학 안내
+            </a>
           </S.GlobalNav>
         )}
       </S.HeaderInner>


### PR DESCRIPTION
## 개요 💡

선생님의 긴급한 요청으로 GNB에 구 홈페이지의 입학 안내 링크를 추가했습니다.

## 작업내용 ⌨️

- Header 및 HamburgerMenu에 [입학 안내](http://gsm.gen.hs.kr/sub/page.php?page_code=entrance_01) 추가
  - 급하게 추가하여 태블릿 사이즈에서 다소 반응형 이슈가 존재합니다. 입학 기간 이후 제거할 예정으로 일단 현행 유지하도록 하겠습니다.
- 기존 Hello,GSM 링크 `입학 -> 입학 접수` 문구 수정

Header
<img width="100%" alt="스크린샷 2023-10-12 오후 2 54 51" src="https://github.com/themoment-team/official-gsm-front/assets/80103328/2030f0a2-19bb-4dd6-a4f7-6a12e6ae7c59">

HamburgerMenu
<img width="400" alt="스크린샷 2023-10-12 오후 2 55 00" src="https://github.com/themoment-team/official-gsm-front/assets/80103328/4b594575-9a5c-4466-8a89-465ee84f8908">

