### PR TITLE
[Client] Add popUpZone

### DIFF
--- a/apps/client/src/components/CategoryHeader/index.tsx
+++ b/apps/client/src/components/CategoryHeader/index.tsx
@@ -6,17 +6,19 @@ import { NewsTitle } from 'client/components';
 import * as S from './style';
 
 interface CategoryHeaderProps {
-  category: 'FAMILY_NEWSLETTER' | 'EVENT_GALLERY';
+  category: 'FAMILY_NEWSLETTER' | 'EVENT_GALLERY' | 'POPUP_ZONE';
 }
 
 const categories = {
   FAMILY_NEWSLETTER: '가정통신문',
   EVENT_GALLERY: '우리 학교 갤러리',
+  POPUP_ZONE: '팝업존',
 } as const;
 
 const categoryHref = {
   FAMILY_NEWSLETTER: '/list/newsletter',
   EVENT_GALLERY: '/list/gallery',
+  POPUP_ZONE: '/',
 } as const;
 
 const CategoryHeader: React.FC<CategoryHeaderProps> = ({ category }) => (

--- a/apps/client/src/components/CategoryHeader/index.tsx
+++ b/apps/client/src/components/CategoryHeader/index.tsx
@@ -6,28 +6,30 @@ import { NewsTitle } from 'client/components';
 import * as S from './style';
 
 interface CategoryHeaderProps {
-  category: 'FAMILY_NEWSLETTER' | 'EVENT_GALLERY' | 'POPUP_ZONE';
+  category: 'FAMILY_NEWSLETTER' | 'EVENT_GALLERY' | 'POPUP_ZONE' | 'MEAL';
 }
 
 const categories = {
   FAMILY_NEWSLETTER: '가정통신문',
   EVENT_GALLERY: '우리 학교 갤러리',
   POPUP_ZONE: '팝업존',
+  MEAL: '급식',
 } as const;
 
 const categoryHref = {
   FAMILY_NEWSLETTER: '/list/newsletter',
   EVENT_GALLERY: '/list/gallery',
-  POPUP_ZONE: '/',
 } as const;
 
 const CategoryHeader: React.FC<CategoryHeaderProps> = ({ category }) => (
   <S.CategoryHeaderWrapper>
     <NewsTitle pointColor='lime'>{categories[category]}</NewsTitle>
-    <S.SeeMoreLink href={categoryHref[category]}>
-      더보기
-      <ChevronIcon />
-    </S.SeeMoreLink>
+    {category !== 'POPUP_ZONE' && category !== 'MEAL' && (
+      <S.SeeMoreLink href={categoryHref[category]}>
+        더보기
+        <ChevronIcon />
+      </S.SeeMoreLink>
+    )}
   </S.CategoryHeaderWrapper>
 );
 

--- a/apps/client/src/components/PopUpCard/index.stories.tsx
+++ b/apps/client/src/components/PopUpCard/index.stories.tsx
@@ -5,7 +5,6 @@ import type { Meta, StoryObj } from '@storybook/react';
 export default {
   title: 'client/PopUpCard',
   component: PopUpCard,
-  parameters: {},
 } as Meta<typeof PopUpCard>;
 
 type Story = StoryObj<typeof PopUpCard>;

--- a/apps/client/src/components/PopUpZone/index.stories.tsx
+++ b/apps/client/src/components/PopUpZone/index.stories.tsx
@@ -1,0 +1,14 @@
+import PopUpZone from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+export default {
+  title: 'client/PopUpZone',
+  component: PopUpZone,
+} as Meta<typeof PopUpZone>;
+
+type Story = StoryObj<typeof PopUpZone>;
+
+export const Light: Story = {
+  args: {},
+};

--- a/apps/client/src/components/PopUpZone/index.tsx
+++ b/apps/client/src/components/PopUpZone/index.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { CategoryHeader } from 'client/components';
+
+import * as S from './style';
+
+const PopUpZone = () => (
+  <S.PopUpZoneWrapper>
+    <CategoryHeader category='POPUP_ZONE' />
+  </S.PopUpZoneWrapper>
+);
+
+export default PopUpZone;

--- a/apps/client/src/components/PopUpZone/index.tsx
+++ b/apps/client/src/components/PopUpZone/index.tsx
@@ -1,12 +1,55 @@
 'use client';
 
-import { CategoryHeader } from 'client/components';
+import { CategoryHeader, PopUpCard } from 'client/components';
 
 import * as S from './style';
+
+const popUpList = [
+  {
+    imgUrl: 'https://cdn.aitimes.kr/news/photo/202303/27617_41603_044.jpg',
+    title:
+      '2023년 중학생 대상 학교 방문 체험 프로그램 2023년 중학생 학교 방문합니다',
+  },
+  {
+    imgUrl: 'https://cdn.aitimes.kr/news/photo/202303/27617_41603_044.jpg',
+    title:
+      '2023년 중학생 대상 학교 방문 체험 프로그램 2023년 중학생 학교 방문합니다',
+  },
+  {
+    imgUrl: 'https://cdn.aitimes.kr/news/photo/202303/27617_41603_044.jpg',
+    title:
+      '2023년 중학생 대상 학교 방문 체험 프로그램 2023년 중학생 학교 방문합니다',
+  },
+  {
+    imgUrl: 'https://cdn.aitimes.kr/news/photo/202303/27617_41603_044.jpg',
+    title:
+      '2023년 중학생 대상 학교 방문 체험 프로그램 2023년 중학생 학교 방문합니다',
+  },
+  {
+    imgUrl: 'https://cdn.aitimes.kr/news/photo/202303/27617_41603_044.jpg',
+    title:
+      '2023년 중학생 대상 학교 방문 체험 프로그램 2023년 중학생 학교 방문합니다',
+  },
+  {
+    imgUrl: 'https://cdn.aitimes.kr/news/photo/202303/27617_41603_044.jpg',
+    title:
+      '2023년 중학생 대상 학교 방문 체험 프로그램 2023년 중학생 학교 방문합니다',
+  },
+];
 
 const PopUpZone = () => (
   <S.PopUpZoneWrapper>
     <CategoryHeader category='POPUP_ZONE' />
+    <S.PopUpList>
+      {popUpList.map((popUp, i) => (
+        <PopUpCard
+          key={i /*추후 유니크한 값으로 변경*/}
+          index={i + 1}
+          imgUrl={popUp.imgUrl}
+          title={popUp.title}
+        />
+      ))}
+    </S.PopUpList>
   </S.PopUpZoneWrapper>
 );
 

--- a/apps/client/src/components/PopUpZone/style.ts
+++ b/apps/client/src/components/PopUpZone/style.ts
@@ -4,15 +4,22 @@ export const PopUpZoneWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 20px;
+  gap: 1.25rem;
 `;
 
 export const PopUpList = styled.div`
   display: grid;
-  width: 887px;
-  height: 458px;
-  padding: 24px 24px 36px 24px;
-  gap: 16px;
+  width: 55.4375rem;
+  height: 28.625rem;
+  padding: 1.5rem 1.5rem 2.25rem 1.5rem;
+  gap: 1rem;
 
   grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+
+  border-radius: 1.25rem;
+  background: #fff;
+
+  /* elevation_blue */
+  box-shadow: 0rem 0.25rem 2.5rem 0rem rgba(175, 198, 209, 0.2);
 `;

--- a/apps/client/src/components/PopUpZone/style.ts
+++ b/apps/client/src/components/PopUpZone/style.ts
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+
+export const PopUpZoneWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 20px;
+`;
+
+export const PopUpList = styled.div`
+  display: grid;
+  width: 887px;
+  height: 458px;
+  padding: 24px 24px 36px 24px;
+  gap: 16px;
+
+  grid-template-columns: repeat(3, 1fr);
+`;


### PR DESCRIPTION
## 개요 💡

> 팝업존을 제작했습니다.

## 작업내용 ⌨️

- PopUpCard를 mapping하는 PopUpZone을 제작했습니다.

<img width="525" alt="image" src="https://github.com/themoment-team/official-gsm-front/assets/106712562/af2cfb1a-f06f-4f12-ab9a-99de8657cfe0">

## 핵심 변경사항 외의 추가적으로 변경된 부분
- CategoryHeader의 더보기 표시 유무를 추가했습니다. (급식이나 팝업존의 경우)

