### PR TITLE
Update footer date

### DIFF
--- a/apps/client/src/components/Footer/index.tsx
+++ b/apps/client/src/components/Footer/index.tsx
@@ -10,6 +10,8 @@ import * as S from './style';
 const Footer = () => {
   const width = useGetWindowWidth();
 
+  const year = new Date().getFullYear();
+
   return (
     <S.Footer>
       <S.FooterContent>
@@ -17,7 +19,7 @@ const Footer = () => {
         <S.FooterTextWrapper>
           <S.SiteInfo>
             <S.Copyright>
-              ©2023 Copyright 광주소프트웨어마이스터고등학교
+              ©{year} Copyright 광주소프트웨어마이스터고등학교
               {width < 700 ? <br /> : ' '}
               ALL RIGHTS RESERVED.
             </S.Copyright>


### PR DESCRIPTION
## 개요 💡

> 연도가 바뀔 때 마다 라이센스 연도를 변경하기 불편하기 때문에 이선우 선배님 방식대로 date를 사용하여 변경했습니다.

## 작업내용 ⌨️
기존 고정된 값으로 되었던 footer의 라이센스 연도를 동적인 Date 객체를 사용하여 변경했습니다.
<img width="822" alt="image" src="https://github.com/themoment-team/official-gsm-front/assets/106712562/9631baa7-d75d-453f-8339-1d3804454dcb">

