### PR TITLE
[Hotfix 검색엔진] 검색 엔진에 인덱스 되지 않도록 메타 태그 추가

### DIFF
--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -64,6 +64,7 @@ export default function RootLayout({
     <html lang='ko'>
       <head>
         <meta name='robots' content='noindex' />
+        <meta name='msvalidate.01' content='14471419A8701E4145F89E3ADCCFB1D6' />
         <link
           rel='stylesheet'
           as='style'

--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -63,6 +63,7 @@ export default function RootLayout({
   return (
     <html lang='ko'>
       <head>
+        <meta name='robots' content='noindex' />
         <link
           rel='stylesheet'
           as='style'


### PR DESCRIPTION
## 개요 💡

> 개별 페이지가 검색 엔진에 의해 인덱스되지 않도록 하려면 HTML의 <head> 섹션에 다음 메타 태그를 추가했습니다.
